### PR TITLE
Add uploadsscripts.handlebars to main

### DIFF
--- a/views/community.handlebars
+++ b/views/community.handlebars
@@ -444,10 +444,3 @@ $("#image-preview").css("background-position", "center center");
 {{/if}}
 </script>
 {{/unless}}
-
-
-{{#unless isMuted}}
-{{#if isMember}}
-{{> uploadscripts}}
-{{/if}}
-{{/unless}}

--- a/views/home.handlebars
+++ b/views/home.handlebars
@@ -10,8 +10,6 @@
 </section>
 {{> filemessage }}
 
-{{> uploadscripts}}
-
 <script>
 $('#postsContainer').infiniteScroll({
   path: function() {

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -73,4 +73,6 @@
 
 {{> scripts}}
 
+{{> uploadscripts}}
+
 </html>

--- a/views/partials/newpostform.handlebars
+++ b/views/partials/newpostform.handlebars
@@ -11,15 +11,6 @@
     <input type="hidden" id="postImageTags" name="postImageTags" /><!-- unused? p sure. -->
     </label>
   </div>
-  <div class="newimageform">
-    <div class="image-preview"></div>
-    <textarea class="form-control mb-3" name="postImageDescription" id="postImageDescription" placeholder="Describe this image for people using screen readers." {{#if sessionFlash.errorImageDescription }}value="{{sessionFlash.errorImageDescription}}" {{/if}}></textarea>
-    <div class="image-preview-controls">
-      <a href="javascript:void(0)" class="image-control image-clear" title="Clear image"><i class="fas fa-times"></i></a>
-      <a href="javascript:void(0)" class="image-control image-move" title="Move image" ondragstart="return false;" ondrop="return false;"><i class="fas fa-arrows-alt"></i></a>
-    </div>
-  </div>
-
   <div class="form-row my-2 card p-1" id="emojiWindow" style="display:none">
     {{> emojilist }}
   </div>

--- a/views/partials/uploadscripts.handlebars
+++ b/views/partials/uploadscripts.handlebars
@@ -1,5 +1,18 @@
+<!-- cloned in the script below to make the image previews -->
+<div class="newimageform">
+  <div class="image-preview"></div>
+  <textarea class="form-control mb-3" name="postImageDescription" id="postImageDescription" placeholder="Describe this image for people using screen readers." {{#if sessionFlash.errorImageDescription }}value="{{sessionFlash.errorImageDescription}}" {{/if}}></textarea>
+  <div class="image-preview-controls">
+    <a href="javascript:void(0)" class="image-control image-clear" title="Clear image"><i class="fas fa-times"></i></a>
+    <a href="javascript:void(0)" class="image-control image-move" title="Move image" ondragstart="return false;" ondrop="return false;"><i class="fas fa-arrows-alt"></i></a>
+  </div>
+</div>
 <script type="text/javascript">
+
 $(function() {
+
+  //NEW POST FORM CODE
+
   $(".editable-post-content").focus(function(){
     $(".post-controls").css('display', 'flex');
   })

--- a/views/user.handlebars
+++ b/views/user.handlebars
@@ -98,6 +98,3 @@ $('#postsContainer').infiniteScroll({
 
 {{> profilescripts}}
 
-{{#if isOwnProfile}}
-{{> uploadscripts}}
-{{/if}}


### PR DESCRIPTION
uploadsscripts is now embedded in main.handlebars (alongside scripts) so it's included in every page now, even though technically it's not actually relevant if you're looking at a community in which you are muted. The newimageform div that gets cloned to produce new image preview windows is now located at the top of uploadscripts even though it's not technically a script thing. But, this way it's included once on every page. (Previously it was part of newpostform and only appeared on pages containing that, which won't work anymore since it's necessary wherever images are being uploaded.) This should be merged and pushed, I think. (*crosses fingers* no new weird edge cases no new weird edge cases)