### PR TITLE
Vue communities page

### DIFF
--- a/app/inhabitingCommunities.js
+++ b/app/inhabitingCommunities.js
@@ -80,6 +80,29 @@ module.exports = function (app, passport) {
       })
   })
 
+  app.get('/vueCommunities', isLoggedIn, function (req, res) {
+    Community.find({ members: req.user._id },
+      {
+        name: 1,
+        imageEnabled: 1,
+        image: 1,
+        slug: 1,
+        membersCount: 1,
+        descriptionParsed: 1
+      })
+      .collation({
+        locale: 'en'
+      })
+      .sort('name')
+      .then((communities) => {
+        res.render('vueCommunities', {
+          loggedIn: true,
+          loggedInUserData: req.user,
+          communitiesJSON: JSON.stringify(communities.map(c => c.toObject()))
+        })
+      })
+  })
+
   app.get('/community', function (req, res) {
     res.redirect('../communities')
   })

--- a/server.js
+++ b/server.js
@@ -14,7 +14,8 @@ const VueLoaderPlugin = require('vue-loader/lib/plugin')
 const compiler = webpack({
   mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',
   entry: {
-    searchPage: './vue/searchPageEntry.js'
+    searchPage: './vue/searchPageEntry.js',
+    communitiesPage: './vue/communitiesPageEntry.js'
   },
   output: {
     filename: './public/js/vue/[name].js',

--- a/views/vueCommunities.handlebars
+++ b/views/vueCommunities.handlebars
@@ -1,0 +1,5 @@
+<script type="application/json" id="joinedCommunities">
+{{{communitiesJSON}}}
+</script>
+<div id="communitiesCont"></div>
+<script src="/js/vue/communitiesPage.js"></script>

--- a/vue/communitiesPageEntry.js
+++ b/vue/communitiesPageEntry.js
@@ -1,0 +1,7 @@
+import Vue from 'vue'
+import CommunitiesPage from './components/TheCommunitiesPage.vue'
+new Vue({
+  el: '#communitiesCont',
+  template: '<CommunitiesPage />',
+  components: { CommunitiesPage }
+})

--- a/vue/components/CommunitiesPageComponents/communitiesList.vue
+++ b/vue/components/CommunitiesPageComponents/communitiesList.vue
@@ -1,0 +1,18 @@
+<template>
+    <div>
+        <div :key="comm._id" v-for="comm in list">
+            {{comm}}
+        </div>
+    </div>
+</template>
+
+<script>
+export default {
+    props: {
+        list: {
+            type: Array,
+            required: true
+        }
+    }
+}
+</script>

--- a/vue/components/TheCommunitiesPage.vue
+++ b/vue/components/TheCommunitiesPage.vue
@@ -1,0 +1,15 @@
+<template>
+    <communitiesList :list="joinedCommunities" />
+</template>
+
+<script>
+import communitiesList from './CommunitiesPageComponents/communitiesList.vue'
+export default {
+    data() {
+        return {
+            joinedCommunities: JSON.parse(document.getElementById('joinedCommunities').innerHTML)
+        }
+    },
+    components: {communitiesList}
+}
+</script>


### PR DESCRIPTION
This is leap 2 in the grand Vue adventure. This PR uses the `communityStub` schema for its communities lists, which looks like this: 
```
{
    _id: String,
    name: String,
    imageEnabled: Boolean,
    image: String,  // url
    slug: String,
    membersCount: Number,
    descriptionParsed: String  // HTML
}
```
The communities form, when creating a new community, sends objects with a different schema, which I'll document when I get around to it. Not entirely sure how to best document (and potentially forcefully validate?) these schemata in the codebase when sending and receiving. It's pretty simple to pull objects with this format from the database, though, and I imagine most of the work this time around will just be messing around with the new community form.