### PR TITLE
Clean up backend post processing

### DIFF
--- a/app/models/image.js
+++ b/app/models/image.js
@@ -1,17 +1,13 @@
 const mongoose = require('mongoose')
+const DBReference = mongoose.Schema.Types.ObjectId
 
 const imageSchema = new mongoose.Schema({
-  context: String, // either "user" or "community", corresponding to the post schema's type field's values "original" and "community"
   filename: { type: String, unique: true },
-  privacy: String,
-  accessToken: String,
-  user: String,
-  community: String,
-  tags: String,
+  post: { type: DBReference, ref: 'Post' },
   description: String,
   height: Number,
   width: Number,
-  quality: String
+  orientation: { type: String, enum: ['horizontal', 'vertical', 'neutral'] }
 })
 
 imageSchema.index({ filename: 1 })

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -1,42 +1,6 @@
 const mongoose = require('mongoose')
 const DBReference = mongoose.Schema.Types.ObjectId
 
-// this is used by older posts instead of the below inlineElementSchema
-const embedSchema = new mongoose.Schema({
-  type: String, // "video" always
-  linkUrl: String,
-  embedUrl: String,
-  title: String,
-  description: String,
-  image: String,
-  domain: String
-})
-
-const inlineElementSchema = new mongoose.Schema({
-  type: String, // either "link-preview" or "image(s)"
-
-  position: Number, // what number "paragraph" this should be when it's mixed into parsedContent, where a paragraph is a <p>...</p>, <ul>...</ul>, or a <blockquote></blockquote>.
-
-  // used if link-preview:
-  isEmbeddableVideo: Boolean,
-  linkUrl: String,
-  embedUrl: String, // only defined if isEmbeddableVideo is true
-  title: String,
-  image: String,
-  description: String,
-  domain: String,
-
-  // used if image(s) (yeah, it's the same parallel arrays as the the old post formats):
-  images: [String],
-  imageDescriptions: [String],
-  // it would take a database transform for the old posts, but these fields should probably be combined into imageOrientationType or something. currently, if an image is vertical
-  // it has 'vertical-image' stored at the same index as it in the imageIsVertical array and a blank string otherwise, and the same for horizontality. imageOrientationType could just
-  // store 'vertical-image', 'horizontal-image', or a blank string.
-  imageIsVertical: [String],
-  imageIsHorizontal: [String]
-})
-
-// this is really similar to the embed schema but i only just realized that and i don't feel like changing this
 const linkPreviewCacheSchema = new mongoose.Schema({
   isEmbeddableVideo: Boolean,
   retrievalUrl: String, // the url without the protocol - this is used to retrieve the document (works if the user inputs the url with http://, https://, or neither)
@@ -48,26 +12,19 @@ const linkPreviewCacheSchema = new mongoose.Schema({
   domain: String
 })
 
+const contentSchema = new mongoose.Schema({
+  type: { type: String, enum: ['html', 'image(s)', 'link preview'] },
+  html: String,
+  images: [{ type: DBReference, ref: 'Image' }],
+  linkPreview: { type: DBReference, ref: 'Cached Link Metadata' }
+})
+
 const commentSchema = new mongoose.Schema({
-  authorEmail: String,
   author: { type: DBReference, ref: 'User' },
   timestamp: Date,
-  rawContent: String,
-  parsedContent: String,
   mentions: [String],
   tags: [String],
-
-  // image parallel arrays
-  images: [String],
-  imageDescriptions: [String],
-  // it would take a database transform for the old posts, but these fields should probably be combined into imageOrientationType or something. currently, if an image is vertical
-  // it has 'vertical-image' stored at the same index as it in the imageIsVertical array and a blank string otherwise, and the same for horizontality. imageOrientationType could just
-  // store 'vertical-image', 'horizontal-image', or a blank string.
-  imageIsVertical: [String],
-  imageIsHorizontal: [String],
-
-  inlineElements: [inlineElementSchema], // this is used instead of the image parallel arrays in newer comments. keep in mind you can't check the post's imageVersion to see if this was used, bc comments using this model can still be made on old posts
-
+  contents: [contentSchema],
   deleted: { type: Boolean, default: false },
   cachedHTML: { // was rendered with either the versions of the templates indicated by the post's corresponding cachedHTML MTimes or the version that was available when the comment was created, whichever is newer
     fullContentHTML: String
@@ -85,15 +42,12 @@ const boostSchema = new mongoose.Schema({
 const postSchema = new mongoose.Schema({
   type: String, // "original", "community", or "boost". note that the equivalent "context" field in image documents stores either "user", "community", or "user"
   community: { type: DBReference, ref: 'Community' }, // hopefully undefined if type=="user"
-  authorEmail: { type: String, required: true },
   author: { type: DBReference, ref: 'User' },
   url: { type: String, required: true },
   privacy: { type: String, required: true },
   timestamp: { type: Date, required: true },
   lastUpdated: Date, // intially equal to timestamp, updated as comments are left
   lastEdited: Date, // initially undefined (although it wouldn't be crazy to set it equal to timestamp initially) and then changed when the post content is edited through the saveedits route in postingToSweet.js
-  rawContent: String, // this was originally used to store plain text input i believe and then suddenly that wasn't a thing anymore and then it stored html input and now it stores a stringified object containing inlineElements objects
-  parsedContent: String, // this is the field that is used to store the text contents of the post in html form and is used to generate the full post html, which is stored in cachedHTML.fullContentHTML below
   comments: [commentSchema],
   boostTarget: { type: DBReference, ref: 'Post' },
   numberOfComments: Number,
@@ -104,27 +58,8 @@ const postSchema = new mongoose.Schema({
   contentWarnings: String,
   commentsDisabled: Boolean,
 
-  // 1: array of filenames stored in /public/images/uploads/[filename] (and so publicly accessible through the url /images/uploads/[filename]);
-  // 2=array of filenames stored in /cdn/images/[filename] accessible through /api/image/display/[filename] (which checks the user's permissions and the image's privacy;) and
-  // 3: image data stored in inlineElements instead and accessible using that second url/path scheme
-  // comments may have an older imageVersion if the post was edited or a newer one if the comments are more recent than the post
-  imageVersion: Number,
-
-  // image parallel arrays (no positions, images were all put at the end):
-  images: [String],
-  imageDescriptions: [String],
-  // it would take a database transform for the old posts, but these fields should probably be combined into imageOrientationType or something. currently, if an image is vertical
-  // it has 'vertical-image' stored at the same index as it in the imageIsVertical array and a blank string otherwise, and the same for horizontality. imageOrientationType could just
-  // store 'vertical-image', 'horizontal-image', or a blank string.
-  imageIsVertical: [String],
-  imageIsHorizontal: [String],
-
-  subscribedUsers: [String],
-  unsubscribedUsers: [String],
-
-  embeds: [embedSchema], // this was only used simultanously with imageVersion 2, so you can check for that i guess. embeds are stored in inlineElements under version 3
-
-  inlineElements: [inlineElementSchema], // this is used instead of the image parallel arrays and the embeds in newer posts
+  subscribedUsers: [{ type: DBReference, ref: 'User' }],
+  unsubscribedUsers: [{ type: DBReference, ref: 'User' }],
 
   cachedHTML: { // the below MTimes also set a floor for the rendering date of the cached comment html (none will have older cached html, newer comments may have newer cached html, either way it'll all be brought up to date when the post is displayed)
     fullContentHTML: String,

--- a/app/utilityFunctionsMostlyText.js
+++ b/app/utilityFunctionsMostlyText.js
@@ -165,8 +165,8 @@ module.exports = {
     }
     const retrievalUrl = parsedUrl.toString()
     let finalUrl // this will have the correct protocol, obtained either by the cache or the request package
-    const Cache = mongoose.model('Cached Link Metadata')
-    const found = await Cache.findOne({ retrievalUrl: retrievalUrl })
+    const LinkMetadata = mongoose.model('Cached Link Metadata')
+    const found = await LinkMetadata.findOne({ retrievalUrl: retrievalUrl })
     const cacheHit = !!found
     let metadata
     if (!cacheHit) {
@@ -228,7 +228,7 @@ module.exports = {
     }
     result.isEmbeddableVideo = isEmbeddableVideo
     if (!cacheHit) {
-      (new Cache(result)).save()
+      await (new LinkMetadata(result)).save()
     }
     return result
   },

--- a/app/viewingSweet.js
+++ b/app/viewingSweet.js
@@ -910,6 +910,7 @@ module.exports = function (app) {
       let canDisplay = false
       if (req.isAuthenticated()) {
         // logged in users can't see private posts by users who don't trust them or community posts by muted members
+        // TODO: urgent: fix this now that post.authorEmail no longer exists
         if ((post.privacy === 'private' && usersWhoTrustMeEmails.includes(post.authorEmail)) || post.privacy === 'public') {
           canDisplay = true
         }
@@ -959,6 +960,7 @@ module.exports = function (app) {
       }
 
       // As a final hurrah, just hide all posts and boosts made by users you've muted
+      // TODO: urgent: fix this now that post.authorEmail no longer exists
       if (req.isAuthenticated() && myMutedUserEmails.includes(post.authorEmail)) {
         canDisplay = false
       }

--- a/app/viewingSweet.js
+++ b/app/viewingSweet.js
@@ -18,77 +18,78 @@ const auth = require('../config/auth.js')
 
 const ObjectId = mongoose.Types.ObjectId
 
+async function hasPermissionToViewPost (isLoggedIn, userDoc, postDoc) {
+  if (!isLoggedIn) {
+    if (postDoc.privacy === 'private') {
+      return false
+    } else {
+      if (postDoc.type === 'user') {
+        if (!postDoc.populated('author')) {
+          await postDoc.populate('author').execPopulate()
+        }
+        return postDoc.author.settings.profileVisibility === 'profileAndPosts'
+      } else if (postDoc.type === 'community') {
+        if (!postDoc.populated('community')) {
+          await postDoc.populate('community').execPopulate()
+        }
+        return postDoc.community.settings.visibility === 'public'
+      }
+    }
+  } else {
+    const postAuthorID = postDoc.populated('author') ? postDoc.author._id : postDoc.author
+    if (postDoc.type === 'draft') {
+      return postAuthorID.equals(userDoc._id)
+    } else if (postDoc.type === 'community') {
+      if (!postDoc.populated('community')) {
+        await postDoc.populate('community').execPopulate()
+      }
+      return postDoc.community.settings.visibility === 'public' ||
+             postDoc.community.members.some(m => m.equals(userDoc._id))
+    } else if (postDoc.type === 'original') {
+      if (postDoc.privacy === 'public') {
+        return true
+      } else {
+        return !!(await Relationship.findOne({ fromUser: postAuthorID, toUser: userDoc._id, type: 'trust' }))
+      }
+    }
+  }
+}
+
 module.exports = function (app) {
   // Responds to get requests for images on the server. If the image is private, checks to see
   // if the user is trusted/in the community first.
   // Input: URL of an image
   // Output: Responds with either the image file or a redirect response to /404 with 404 status.
   app.get('/api/image/display/:filename', function (req, res) {
-    function sendImageFile () {
-      const imagePath = global.appRoot + '/cdn/images/' + req.params.filename
-      try {
-        if (fs.existsSync(imagePath)) {
-          res.sendFile(imagePath)
-        }
-      } catch (err) {
-        // Image file doesn't exist on server
-        console.log('Image ' + req.params.filename + " doesn't exist on server!")
-        console.log(err)
-        res.status('404')
-        res.redirect('/404')
-      }
-    }
-
-    Image.findOne({ filename: req.params.filename }).then(image => {
+    Image.findOne({ filename: req.params.filename }).then(async image => {
       if (image) {
-        if (image.privacy === 'public') {
-          sendImageFile()
-        } else if (image.privacy === 'private') {
-          if (req.isAuthenticated()) {
-            if (image.user === req.user._id.toString()) {
-              sendImageFile()
-            } else if (image.context === 'user') {
-              Relationship.findOne({ toUser: req.user._id, value: 'trust', fromUser: image.user }).then(rel => {
-                if (rel) {
-                  sendImageFile()
-                } else {
-                  // User not trusted by image's uploader
-                  console.log('User not trusted!')
-                  res.status('404')
-                  res.redirect('/404')
-                }
-              })
-            } else if (image.context === 'community') {
-              Community.findOne({ _id: image.community, members: req.user._id }).then(comm => {
-                if (comm) {
-                  sendImageFile()
-                } else {
-                  // User not a member of this community
-                  console.log(req)
-                  console.log(image)
-                  console.log('User not a community member!')
-                  res.status('404')
-                  res.redirect('/404')
-                }
-              })
+        const parentPost = await Post.findById(image.post)
+        if (hasPermissionToViewPost(req.isAuthenticated(), req.user, parentPost)) {
+          const imagePath = global.appRoot + '/cdn/images/' + req.params.filename
+          try {
+            if (fs.existsSync(imagePath)) {
+              res.sendFile(imagePath)
             }
-          } else {
-            // User not logged in, but has to be to see this image
-            console.log('User not logged in!')
+          } catch (err) {
+            // Image file doesn't exist on server
+            console.log('Image ' + req.params.filename + " doesn't exist on server!")
+            console.log(err)
             res.status('404')
             res.redirect('/404')
           }
+        } else {
+          console.log(`permission denied to view image: ${req.params.filename}`)
+          res.status('404')
+          res.redirect('/404')
         }
       } else {
-        // Image entry not found in database
         console.log('Image ' + image.filename + ' not in database!')
         res.status('404')
         res.redirect('/404')
       }
     })
       .catch(error => {
-        // Unexpected error
-        console.log('Unexpected error displaying image')
+        console.log('Unexpected error retrieving image document from database')
         console.log(error)
         res.status('404')
         res.redirect('/404')
@@ -712,10 +713,6 @@ module.exports = function (app) {
     let myCommunities
     let usersWhoTrustMeEmails
 
-    // const myFlaggedUserEmails
-    // const myTrustedUserEmails
-    // const usersFlaggedByMyTrustedUsers
-
     // build some user lists. only a thing if the user is logged in.
     // todo: instead of pulling them from the relationships collection, at least the first 4 could be arrays of references to other users in the user document, that would speed things up
     if (req.isAuthenticated()) {
@@ -845,7 +842,6 @@ module.exports = function (app) {
       .populate('boostTarget')
       .populate('boostsV2.booster')
 
-    // so this will be called when the query retrieves the posts we want
     const posts = await query
 
     if (!posts || !posts.length) {

--- a/databasetransforms/unifyPostSchemas.js
+++ b/databasetransforms/unifyPostSchemas.js
@@ -1,0 +1,97 @@
+const Post = require('../app/models/post.js')
+const Image = require('../app/models/image')
+const LinkMetadata = mongoose.model('Cached Link Metadata')
+const helper = require('../app/utilityFunctionsMostlyText.js')
+const sharp = require('sharp')
+var configDatabase = require('../config/database.js')
+var mongoose = require('mongoose')
+const ObjectId = require('mongoose').Types.ObjectId
+mongoose.connect(configDatabase.url, {
+  useNewUrlParser: true
+})
+
+async function updateImageDocsFromParallelArrays (doc, images, imageDescriptions, parentPost, position = -1) {
+  const imageDBReferences = []
+  for (let i = 0; i < images.length; i++) {
+    const filename = images[i]
+    const desc = imageDescriptions[i]
+    const image = await Image.find({ filename })
+    image.description = desc
+    image.post = parentPost._id
+    if (image.height && image.width) {
+      if (image.width / image.height < 0.75) {
+        image.orientation = 'vertical'
+      } else if (image.width / image.height > 1.33) {
+        image.orientation = 'horizontal'
+      } else {
+        image.orientation = 'neutral'
+      }
+    }
+    await image.save()
+    imageDBReferences.push(image._id)
+  }
+  return imageDBReferences
+}
+
+async function updateImageDocsFromInlineElements (doc, inlineElements, parentPost) {
+  let imageGroups
+  for (const ie of inlineElements) {
+    if (ie.type === 'image(s)') {
+      imageGroups.push(await updateImageDocsFromParallelArrays(doc, ie.images, ie.imageDescriptions, parentPost, ie.position))
+    }
+  }
+}
+
+async function recursiveImageUpdate (doc, post) {
+  if (doc.images) {
+    const imageDBReferences = await updateImageDocsFromParallelArrays(doc, doc.images, doc.imageDescriptions, post)
+    doc.contents = [{ type: 'html', html: doc.parsedContents }, { type: 'image(s)', images: imageDBReferences }]
+    if (doc.embeds) {
+      for (const embed of doc.embeds) {
+        let embedMetadata = LinkMetadata.findOne({ linkUrl: embed.linkUrl })
+        if (!embedMetadata) {
+          await helper.getLinkMetadata(embed.linkUrl)
+          embedMetadata = LinkMetadata.findOne({ linkUrl: embed.linkUrl })
+        }
+        doc.contents.push({ type: 'link preview', linkPreview: embedMetadata._id })
+      }
+    }
+  } else if (doc.inlineElements) {
+    const imageGroups = updateImageDocsFromInlineElements(doc, doc.inlineElements, post)
+    const contents = [...doc.parsedContents.matchAll(/(<p>.*?<\/p>)|(<ul>.*?<\/ul>)|(<blockquote>.*?<\/blockquote>)/g)]
+    let addedElements = 0
+    let currentElement = {}
+    for (const ie of doc.inlineElements) {
+      if (ie.type === 'link-preview') {
+        currentElement = { type: 'link preview', linkPreview: (await LinkMetadata.findOne({ linkUrl: ie.linkUrl })) }
+      } else if (ie.type === 'image(s)') {
+        currentElement = { type: 'image(s)', images: imageGroups[0] }
+        imageGroups.splice(0, 1)
+      } else {
+        throw Error('malformed inlineElement in post ' + post._id)
+      }
+      contents.splice(ie.position + addedElements, 0, currentElement)
+      addedElements++
+    }
+  }
+  for (const comment in doc.comments) {
+    await recursiveImageUpdate(comment, post)
+  }
+  for (const comment in doc.replies) {
+    await recursiveImageUpdate(comment, post)
+  }
+}
+
+Post.find().then(async posts => {
+  for (const post in posts) {
+    const newSubscribedUsers = []
+    const newUnsubscribedUsers = []
+    for (const user in post.subscribedUsers) {
+      newSubscribedUsers.push(new ObjectId(user))
+    }
+    for (const user in post.unsubscribedUsers) {
+      newUnsubscribedUsers.push(new ObjectId(user))
+    }
+    await recursiveImageUpdate(post, post)
+  }
+})


### PR DESCRIPTION
Goals:

1. Update the post and image schemas as described in #180. ✔
2. Write (✔) and carefully a test a single-use migration scripts to bring the old post and image documents up to date with the new schema.
3. Change the image retrieval (✔) and post rendering functions so they work with the new schema.
4. Break up the 435-line showposts route handler to have separate functions for retrieving posts for different types of pages for the database and ideally separate functions for setting up the separate kinds of metadata (boost headers, custom metadata) as well.