### PR TITLE
Add support for ctrl/cmd-enter to submit on comments and posts

### DIFF
--- a/public/js/newPostOrCommentScripts.js
+++ b/public/js/newPostOrCommentScripts.js
@@ -327,14 +327,17 @@ $(function () {
     }
   })
 
-  //function for very specifically submitting a post, not a comment
-  $("#postSubmit").click(function (e) {
+  // function for very specifically submitting a post, not a comment
+  $("#postForm").submit(function (e) {
     e.preventDefault();
-    $("#editPostModal").remove(); //so if it's on the page (hidden) we don't accidentally select elements in it
+    e.stopPropagation();
+    // so if it's on the page (hidden) we don't accidentally select elements in it
+    $("#editPostModal").remove(); 
     let editor = $('#editor');
-    let postContent = editor[0].getContents(); //array of paragraphs and embeds if we have embeds; normal html string if not
+    // array of paragraphs and embeds if we have embeds; normal html string if not
+    let postContent = editor[0].getContents(); 
     if (editor[0].hasContent()) {
-      var button = $(this);
+      var button = $("#postSubmit");
       button.attr('disabled', true);
       $.ajax({
         url: '/createpost',
@@ -342,11 +345,17 @@ $(function () {
         data: {
           communityId: $('#postForm').attr("communityId"),
           isDraft: $("#pseudoPrivacy-draft").is(":checked") ? true : "",
-          postPrivacy: ($('#postPrivacy-public').is(':checked') ? 'public' : 'private'), //public posts are public; private posts and drafts are private
-          postContent: JSON.stringify(postContent), //doesn't actually need to be stringified if it happens to just be html (in a no embeds situation) but, doesn't hurt, the server JSON.parses this field regardless
+          // public posts are public; private posts and drafts are private
+          postPrivacy: ($('#postPrivacy-public').is(':checked') ? 'public' : 'private'), 
+          // doesn't actually need to be stringified if it happens to just be
+          // html (in a no embeds situation) but, doesn't hurt, the server
+          // JSON.parses this field regardless
+          postContent: JSON.stringify(postContent), 
           postContentWarnings: $('#postContentWarnings').val(),
         }
-      }).done(function (postTimestamp) { //this will be a string with timestamp 1 millisecond later than the new post's timestamp
+      }).done(function (postTimestamp) {
+        // postTimestamp will be a string with timestamp 1 millisecond later
+        // than the new post's timestamp
         $('#postContentWarnings').val("");
         $("#postContentWarningsContainer").slideUp("fast");
         $("#new-post-emoji-picker").slideUp("fast");
@@ -354,18 +363,28 @@ $(function () {
         var innerEditor = editor.find(".ql-editor");
         innerEditor.html("");
         button.attr('disabled', false);
-        //restart the feed to show the new post, unless we've just created a draft and aren't currently looking at our drafts and thus won't see it anyway, in which case just display a message talking about the draft in the editor
+        // restart the feed to show the new post, unless we've just created a
+        // draft and aren't currently looking at our drafts and thus won't see
+        // it anyway, in which case just display a message talking about the
+        // draft in the editor
         if (!$("#pseudoPrivacy-draft").is(":checked") || (typeof draftsMode != "undefined" && draftsMode)) {
           if (!$("#pseudoPrivacy-draft").is(":checked") && typeof draftsMode != "undefined" && draftsMode) {
-            //if we've just created a regular post and are currently looking at our drafts, we need to switch to looking at regular posts to see our new post
+            // if we've just created a regular post and are currently looking
+            // at our drafts, we need to switch to looking at regular posts to
+            // see our new post
             draftsMode = false;
           }
-          restartInfiniteScroll(postTimestamp) //we'll requests posts older than that specific timestamp, so the new post should always be on top, with any even newer posts not shown.
+          // we'll requests posts older than that specific timestamp, so the
+          // new post should always be on top, with any even newer posts not
+          // shown.
+          restartInfiniteScroll(postTimestamp) 
         } else {
           innerEditor.attr("data-placeholder", 'Post saved to drafts; view those through your profile.');
           innerEditor.focus(function () {
-            innerEditor.attr("data-placeholder", editor[0].__quill.options.placeholder); //this will retrieve the editor's original placeholder and looks weird
-            innerEditor.off("focus"); //don't need to reset the placeholder more than once
+            // this will retrieve the editor's original placeholder and looks weird
+            innerEditor.attr("data-placeholder", editor[0].__quill.options.placeholder); 
+            // don't need to reset the placeholder more than once
+            innerEditor.off("focus"); 
           })
         }
       }).fail(function () {
@@ -378,9 +397,11 @@ $(function () {
   });
 
   //function for sumbitting a comment and then placing the new comment on the page
-  $('body').on('click', '.create-comment', function () {
-    let commentButton = $(this);
-    let commentForm = commentButton.closest('.new-comment-form');
+  $('body').on('submit', '.new-comment-form', function (e) {
+    e.preventDefault();
+    e.stopPropagation();
+    let commentButton = $(this).find('button.create-comment');
+    let commentForm = $(this)
     let commentType = commentForm.attr('data-comment-type');
     let postID = commentForm.attr('data-post-id');
     let commentID = commentForm.attr('data-comment-id');
@@ -396,7 +417,10 @@ $(function () {
 
     if (commentContainer[0].hasContent()) {
       commentButton.prop('disabled', true);
-      $.post("/createcomment/" + postID + "/" + commentID, { commentContent: JSON.stringify(commentContent) }, //doesn't actually need to be stringified if it happens to just be html (in a no embeds situation) but, doesn't hurt, the server JSON.parses this field regardless
+      // doesn't actually need to be stringified if it happens to just be html
+      // (in a no embeds situation) but, doesn't hurt, the server JSON.parses
+      // this field regardless
+      $.post("/createcomment/" + postID + "/" + commentID, { commentContent: JSON.stringify(commentContent) },
         function (data) {
           if (data != 'nope') {
             commentEditor.html('');

--- a/public/js/textEditorScripts.js
+++ b/public/js/textEditorScripts.js
@@ -1,5 +1,7 @@
-//okay so the below is the code that configures the quill.js text editor to work how we want it to vis-a-vis text formatting and using inline image and
-//link preview elements, both of which i'm referring to as "embeds" bc i can't think of a better name. "inlines"?
+//okay so the below is the code that configures the quill.js text editor to
+//work how we want it to vis-a-vis text formatting and using inline image and
+//link preview elements, both of which i'm referring to as "embeds" bc i can't
+//think of a better name. "inlines"?
 
 //within-editor embeds utility functions:
 function updateSubmitButtonState(postForm) {
@@ -20,7 +22,9 @@ function updateSubmitButtonState(postForm) {
     }
 }
 
-//attached directly to the onclick of the x in the embeds when a new one is created (bc of user action or rearrangement). this click event is also artificially triggered when an embed has an error
+//attached directly to the onclick of the x in the embeds when a new one is
+//created (bc of user action or rearrangement). this click event is also
+//artificially triggered when an embed has an error
 function clearEmbed(e) {
     var container = $(this).closest('.slidable-embed');
     if (container.hasClass('image-preview-container') && !container.attr('imagealreadysaved') && !container.hasClass('still-loading')) {
@@ -852,4 +856,20 @@ window.addEventListener("beforeunload", function(event) {
             $.post('/cleartempimage', { imageURL: e.getAttribute('image-url') });
         }
     })
+});
+
+
+/* Hilarity: metaKey only registers key combos on keydown, not keyup. Welp. */
+window.addEventListener("keydown", function(event) {
+  var shouldSubmit = (event.keyCode === 10 || event.keyCode === 13) && (event.ctrlKey || event.metaKey);
+  if (shouldSubmit && event.target) {
+    // We must use jQuery's idea of submit, not raw JS submit, to hit the
+    // submit logic we've written.
+    if (event.target.closest('#postForm')) {
+      $(event.target.closest('#postForm')).submit();
+    }
+    if (event.target.closest('.new-comment-form')) {
+      $(event.target.closest('.new-comment-form')).submit();
+    }
+  }
 });

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -52,7 +52,7 @@
 
   {{#if loggedIn}}
     {{>newPostFormTemplatesContainer}}
-    <script src="/js/textEditorScripts.min.js"></script>
+    <script src="/js/textEditorScripts.js"></script>
   {{/if}}
 
   {{> onPostLoadScripts }}

--- a/views/partials/newreplyform.handlebars
+++ b/views/partials/newreplyform.handlebars
@@ -1,4 +1,4 @@
-<div class="new-comment-form" data-comment-type="primary" data-post-id="{{#eq activePage 'singlepost'}}{{post._id}}{{else}}{{this._id}}{{/eq}}">
+<form class="new-comment-form" data-comment-type="primary" data-post-id="{{#eq activePage 'singlepost'}}{{post._id}}{{else}}{{this._id}}{{/eq}}">
 <input type="file" class="file-input" accept="image/gif, image/jpeg, image/png" aria-label="Choose image" name="postImage" multiple>
   <div class="form-row">
     <div class="editable-post-content editable-text" id="postContent">
@@ -24,4 +24,4 @@
       <button type="submit" class="button create-comment">Reply <i class="fas fa-chevron-right"></i></button>
     </div>
   </div>
-</div>
+</form>

--- a/views/partials/scriptPartials/newCommentFormTemplate.handlebars
+++ b/views/partials/scriptPartials/newCommentFormTemplate.handlebars
@@ -1,5 +1,5 @@
 <script id="new-comment-form-template" type="text/custom-template">
-<div class="new-comment-form" data-comment-type="\{{comment_type}}" data-post-id="\{{post_id}}" data-comment-id="\{{comment_id}}">
+<form class="new-comment-form" data-comment-type="\{{comment_type}}" data-post-id="\{{post_id}}" data-comment-id="\{{comment_id}}">
   <input type="file" class="file-input" accept="image/gif, image/jpeg, image/png" aria-label="Choose image" name="postImage" multiple>
   <div class="form-row">
     <div class="editable-post-content editable-text" id="postContent">
@@ -65,5 +65,5 @@
       <button type="submit" class="button create-comment">Reply <i class="fas fa-chevron-right"></i></button>
     </div>
   </div>
-</div>
+</form>
 </script>


### PR DESCRIPTION
Because keyboards!

I also moved from intercepting click events, to intercepting submit events. Not that that will matter in the long-term, as we move towards more of a Vue frontend, which can handle that more cleanly still.

The required cute animal picture:

![seal photobombing some penguins](https://static.boredpanda.com/blog/wp-content/uploads/2020/08/funny-laughing-seals-14-5f28106057683__700.jpg)