### PR TITLE
Add type="button" to some more buttons

### DIFF
--- a/views/partials/newpostform.handlebars
+++ b/views/partials/newpostform.handlebars
@@ -15,7 +15,7 @@
   <div class="link-form-cont"> {{! this is only here bc jquery applies display:block when it slides something down, which would break the below div if it slid down that}}
     <div class="my-2 linkPreviewAddingForm">
       <input type="text" class="form-control" name="linkPreviewUrlEntry" id="linkPreviewUrlEntry" placeholder="endless.horse" />
-      <button class="button grey-button link-add" style="margin-left: 0.5rem;"><i class="fas fa-arrow-up"></i></button>
+      <button type="button" class="button grey-button link-add" style="margin-left: 0.5rem;"><i class="fas fa-arrow-up"></i></button>
     </div>
   </div>
   <div id="bottomPostControlsRow" class="mt-2 post-controls">

--- a/views/partials/newreplyform.handlebars
+++ b/views/partials/newreplyform.handlebars
@@ -11,7 +11,7 @@
   <div class="link-form-cont"> {{! this is only here bc jquery applies display:block when it slides something down, which would break the below div if it slid down that}}
     <div class="my-2 linkPreviewAddingForm">
       <input type="text" class="form-control" name="linkPreviewUrlEntry" id="linkPreviewUrlEntry" placeholder="endless.horse" />
-      <button class="button grey-button ml-1 link-add" style="margin-left: 0.5rem;"><i class="fas fa-arrow-up"></i></button>
+      <button type="button" class="button grey-button ml-1 link-add" style="margin-left: 0.5rem;"><i class="fas fa-arrow-up"></i></button>
     </div>
   </div>
   <div id="replyControlsRow" class="form-row mt-2 post-controls">


### PR DESCRIPTION
This, per HTML spec, makes the button not do anything. The default, "submit", causes the form to submit. Therefore, this is what we want to avoid accidentally submitting the post or comment.

Beep boop.